### PR TITLE
Fixed Handling Error that was caused drive_name to be 8000 empty newlines for some files

### DIFF
--- a/sgd/streams.py
+++ b/sgd/streams.py
@@ -47,7 +47,8 @@ class Streams:
         file_size = hr_size(int(self.item.get("size")))
         drive_id = self.item.get("driveId")
         drive_name = self.gdrive.drive_names.contents.get(drive_id, "MyDrive")
-
+        drive_name.strip()
+        
         str_format = "🎥;%codec 🌈;%bitDepth;bit 🔊;%audio 👤;%encoder"
         suffix = self.parsed.get_str(str_format)
         return f"{file_name}\n💾 {file_size} ☁️ {drive_name}\n{suffix}"

--- a/sgd/streams.py
+++ b/sgd/streams.py
@@ -47,7 +47,8 @@ class Streams:
         file_size = hr_size(int(self.item.get("size")))
         drive_id = self.item.get("driveId")
         drive_name = self.gdrive.drive_names.contents.get(drive_id, "MyDrive")
-        drive_name.strip()
+        if len(drive_name) > 30 :
+            drive_name="Error"
         
         str_format = "🎥;%codec 🌈;%bitDepth;bit 🔊;%audio 👤;%encoder"
         suffix = self.parsed.get_str(str_format)

--- a/sgd/streams.py
+++ b/sgd/streams.py
@@ -47,7 +47,7 @@ class Streams:
         file_size = hr_size(int(self.item.get("size")))
         drive_id = self.item.get("driveId")
         drive_name = self.gdrive.drive_names.contents.get(drive_id, "MyDrive")
-        if len(drive_name) > 30 :
+        if len(drive_name) > 100 :
             drive_name="Error"
         
         str_format = "🎥;%codec 🌈;%bitDepth;bit 🔊;%audio 👤;%encoder"


### PR DESCRIPTION
Hi! this was causing file names to break on android. Drive name was just 8000 new lines.
![Screenshot_20221203-215251_Stremio](https://user-images.githubusercontent.com/64459957/205452225-be1d46b4-4909-4520-8ee5-a9c335a7a8df.png)
